### PR TITLE
fix: tree-sitter generate does not support --no-bindings option

### DIFF
--- a/src/luarocks/build/treesitter-parser.lua
+++ b/src/luarocks/build/treesitter-parser.lua
@@ -65,7 +65,7 @@ function treesitter_parser.run(rockspec, no_install)
 	end
 	if build.generate then
 		local cmd
-		cmd = { "tree-sitter", "generate", "--no-bindings" }
+		cmd = { "tree-sitter", "generate" }
 		local abi = os.getenv("TREE_SITTER_LANGUAGE_VERSION")
 		if abi then
 			table.insert(cmd, "--abi")


### PR DESCRIPTION
## Details

Since the release of tree-sitter 0.26.1 the --no-bindings flag has been removed from the CLI and now causes errors:

- [Commit](https://github.com/tree-sitter/tree-sitter/pull/4292)
- [Release](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.26.1)

This is causing the LuaRocks Upload action to fail if the package depends on any parser that need to be generated, [example](https://github.com/MeanderingProgrammer/render-markdown.nvim/actions/runs/20792699740).